### PR TITLE
Add upload endpoint tests and file generators

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+
+from main import app
+from api import upload
+from .utils import (
+    create_text_bytes,
+    create_empty_zip_bytes,
+    create_pdf_bytes,
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_invalid_file(client):
+    """Sending a plain text file should return an error."""
+    files = {"file": ("test.txt", create_text_bytes(), "text/plain")}
+    resp = client.post("/upload", files=files)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "File type not supported"
+
+
+def test_timeout(client, monkeypatch):
+    """Simulate a timeout during metadata extraction."""
+    def _timeout(*args, **kwargs):
+        raise HTTPException(status_code=504, detail="Processing timeout")
+
+    monkeypatch.setattr(upload, "_extract_metadata", _timeout)
+    files = {"file": ("file.pdf", create_pdf_bytes(), "application/pdf")}
+    resp = client.post("/upload", files=files)
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "Processing timeout"
+
+
+def test_empty_zip(client):
+    """Uploading an empty ZIP should return an error."""
+    files = {"file": ("empty.zip", create_empty_zip_bytes(), "application/zip")}
+    resp = client.post("/upload", files=files)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "ZIP file is empty"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,58 @@
+import zipfile
+from io import BytesIO
+
+import pydicom
+from pydicom.dataset import Dataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
+from PyPDF2 import PdfWriter
+from PIL import Image
+
+
+def create_fake_dicom_bytes() -> bytes:
+    """Generate a minimal valid DICOM file in memory."""
+    meta = FileMetaDataset()
+    meta.MediaStorageSOPClassUID = generate_uid()
+    meta.MediaStorageSOPInstanceUID = generate_uid()
+    meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds = Dataset()
+    ds.PatientName = "Test"
+    ds.Rows = 1
+    ds.Columns = 1
+    ds.file_meta = meta
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+
+    buffer = BytesIO()
+    ds.save_as(buffer, write_like_original=False)
+    return buffer.getvalue()
+
+
+def create_empty_zip_bytes() -> bytes:
+    """Create bytes for an empty ZIP archive."""
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w"):
+        pass
+    return buffer.getvalue()
+
+
+def create_pdf_bytes() -> bytes:
+    """Create bytes for a simple one-page PDF file."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def create_image_bytes(format: str = "PNG") -> bytes:
+    """Create bytes for a simple image."""
+    image = Image.new("RGB", (10, 10), color="red")
+    buffer = BytesIO()
+    image.save(buffer, format=format)
+    return buffer.getvalue()
+
+
+def create_text_bytes() -> bytes:
+    """Create bytes for a plain text file."""
+    return b"example text"


### PR DESCRIPTION
## Summary
- add pytest suite for upload endpoint covering invalid file, timeout, and empty zip scenarios
- include utilities for generating in-memory DICOM, PDF, ZIP, image, and text files for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68afb631c1f88323a022401b0effc3b7